### PR TITLE
fix:#01 gsap.toではうまく挙動しない

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,6 @@
     </div>
     <div class="item">Item 3</div>
     <img id="target-img" src="./img/output0.jpg">
-    <script type="module" src="./post-processing/bk_app.js"></script>
+    <script type="module" src="./post2/app.js"></script>
   </body>
 </html>

--- a/src/post2/app.js
+++ b/src/post2/app.js
@@ -1,0 +1,159 @@
+/**
+ * Three.js
+ * https://threejs.org/
+ */
+import * as THREE from "three";
+import vertexShader from "./vertex.glsl";
+import fragmentShader from "./fragment.glsl";
+import GUI from "lil-gui";
+import { gsap } from "gsap";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
+
+init();
+async function init() {
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(
+    75,
+    window.innerWidth / window.innerHeight,
+    0.1,
+    100
+  );
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setClearColor(0xffffff);
+  document.body.appendChild(renderer.domElement);
+
+  async function loadTex(url) {
+    const texLoader = new THREE.TextureLoader();
+    const texture = await texLoader.loadAsync(url);
+    texture.wrapS = THREE.ClampToEdgeWrapping;
+    texture.wrapT = THREE.MirroredRepeatWrapping;
+    return texture;
+  }
+
+  const geometry = new THREE.PlaneGeometry(25, 12.5);
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      uTex1: { value: await loadTex("/img/output4.jpg") },
+      uTex2: { value: await loadTex("/img/output5.jpg") },
+      uTex3: { value: await loadTex("/img/output6.jpg") },
+      uTex4: { value: await loadTex("/img/output7.jpg") },
+      uTick: { value: 0 },
+      uProgress: { value: 0 },
+      uProgress2: { value: 0 },
+      uIndex: { value: 0 },
+    },
+    vertexShader,
+    fragmentShader,
+  });
+  const plane = new THREE.Mesh(geometry, material);
+  scene.add(plane);
+
+  camera.position.set(0, 0, 20);
+
+  const axis = new THREE.AxesHelper(100);
+  scene.add(axis);
+
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+
+  const gui = new GUI();
+  const folder1 = gui.addFolder("mix");
+  folder1.open();
+
+  folder1
+    .add(material.uniforms.uProgress, "value", 0, 1, 0.1)
+    .name("mix")
+    .listen();
+
+  const datData = { next: !!material.uniforms.uProgress.value };
+  folder1
+    .add(datData, "next")
+    .name("mix next")
+    .onChange(() => {
+      gsap.to(material.uniforms.uProgress, {
+        value: datData.next ? 1 : 0,
+        duration: 3,
+        ease: "ease",
+      });
+    });
+
+  await Promise.all([
+    material.uniforms.uTex1.value.image.onload,
+    material.uniforms.uTex2.value.image.onload,
+    material.uniforms.uTex3.value.image.onload,
+  ]);
+
+  startGsapAnimation();
+
+  function startGsapAnimation() {
+    let uIndex = 0;
+    function update() {
+      gsap.to(material.uniforms.uTick, {
+        value: 10.0, //目標値
+        duration: 0.1, //時間
+        ease: "ease", //イージング
+        onComplete: () => {
+          if (uIndex === 0) {
+            gsap.to(material.uniforms.uProgress, {
+              value: 1.0, //目標値
+              duration: 2.0, //時間
+              ease: "ease", //イージング
+              onComplete: () => {
+                uIndex++;
+                update();
+                console.log("uIndex=1");
+                console.log(uIndex);
+              },
+            });
+          } else if (uIndex === 1) {
+            gsap.to(material.uniforms.uProgress, {
+              value: 1.0,
+              duration: 4.0,
+              ease: "ease",
+              onComplete: () => {
+                uIndex++;
+                update();
+                console.log("uIndex=2");
+                console.log(uIndex);
+              },
+            });
+          } else if (uIndex === 2) {
+            gsap.to(material.uniforms.uProgress, {
+              value: 1.0,
+              duration: 4.0,
+              ease: "ease",
+              onComplete: () => {
+                uIndex++;
+                update();
+                console.log("uIndex=3");
+                console.log(uIndex);
+              },
+            });
+          }
+        },
+      });
+
+      console.log(uIndex);
+    }
+    update();
+  }
+
+
+  let i = 0;
+  function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+
+    material.uniforms.uTick.value += 0.01;
+
+    // cube.rotation.x = cube.rotation.x + 0.01;
+    // cube.rotation.y += 0.01;
+
+    renderer.render(scene, camera);
+    // console.log(uIndex)
+  }
+
+  animate();
+}

--- a/src/post2/fragment.glsl
+++ b/src/post2/fragment.glsl
@@ -1,0 +1,49 @@
+precision mediump float;
+
+varying vec2 vUv;
+uniform sampler2D uTex1;
+uniform sampler2D uTex2;
+uniform sampler2D uTex3;
+uniform sampler2D uTex4;
+uniform float uTick;
+uniform float uProgress;
+uniform float uProgress2;
+uniform float uIndex;
+
+void main() {
+
+  vec2 uv = vUv;
+  vec4 color1 = texture2D(uTex1, uv);
+  vec4 color2 = texture2D(uTex2, uv);
+  vec4 color3 = texture2D(uTex3, uv);
+  vec4 color4 = texture2D(uTex4, uv);
+
+  float tempIndex = uIndex;
+  float tempProgress = uProgress;
+// Check if uProgress animation is complete (uProgress reaches 1)
+  if(tempProgress >= 1.0) {
+    // Increase uIndex to switch to the next texture
+    tempIndex = mod(tempIndex + 1.0, 3.0); // Assuming you have 3 textures
+    // Reset uProgress to start the animation again
+    // tempProgress = 0.0;
+  }
+
+  if(tempIndex == 0.0) {
+    vec4 finalColor = mix(color1, color2, tempProgress);
+    gl_FragColor = finalColor;
+  } else if(tempIndex == 1.0) {
+    vec4 finalColor = mix(color2, color3, tempProgress);
+    gl_FragColor = finalColor;
+  } else if(tempIndex == 2.0) {
+    vec4 finalColor = mix(color3, color4, tempProgress);
+    gl_FragColor = finalColor;
+  } else if(tempIndex == 3.0) {
+    vec4 finalColor = mix(color4, color1, tempProgress);
+    gl_FragColor = finalColor;
+  } else {
+    // Handle other index values if needed
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0); // Default color if index is not matched
+  }
+  // gl_FragColor = vec4(tempProgress / 3.0, 0.0, 0.0, 1.0);
+  // gl_FragColor = vec4(tempIndex / 3.0 / 0.0, 0.0, 0.0, 1.0);
+}

--- a/src/post2/vertex.glsl
+++ b/src/post2/vertex.glsl
@@ -1,0 +1,6 @@
+varying vec2 vUv;
+
+void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}


### PR DESCRIPTION
gsap.toではテクスチャの切り替えがうまくいかない。
表示がおかしいです。color1からcolor2まではmixが効いている。color2からcolor3はmixが効いていなくて、rogが１になった瞬間にcolor2からcolor3に突然切り替わってしまいます。

コンソールに表示されているログは期待通りの順序で表示されているようですね。アニメーションが正常に実行され、uIndexが更新されていることが確認できます。

(log確認状況はokそうでした）
最初に uIndex が 0 から 1 へ、次に 1 から 2 へ、最後に 2 から 3 へと順番に更新されていることがわかります。アニメーションの各段階でコンソールに出力されるログも正しく表示されています。したがって、アニメーションと uIndex の更新は期待通りに動作しているようです。

次はタイムラインで取り組むべし