### PR TITLE
Mix3

### DIFF
--- a/src/vertex.html
+++ b/src/vertex.html
@@ -7,7 +7,7 @@
       Memorandum of understanding and practice journey when implementing
     </title>
     <!-- <link rel="stylesheet" href="style copy.css" /> -->
-    <script type="module" src="./vertexedit3/app.js"></script>
+    <script type="module" src="./vertexedit4/app.js"></script>
   </head>
   <body>
     <div id="page-container">

--- a/src/vertexedit4/app.js
+++ b/src/vertexedit4/app.js
@@ -97,7 +97,7 @@ async function init() {
     },
     vertexShader,
     fragmentShader,
-    wireframe: true,
+    // wireframe: true,
     side: THREE.DoubleSide,
   });
   const mesh = new THREE.Mesh(geometry, material);

--- a/src/vertexedit4/app.js
+++ b/src/vertexedit4/app.js
@@ -54,8 +54,8 @@ async function init() {
   }
 
   function setupGeometry() {
-    const wSeg = 3,
-      hSeg = 3;
+    const wSeg = 1,
+      hSeg = 1;
     const geometry = new THREE.BufferGeometry();
     const plane = new THREE.PlaneGeometry(50, 25, wSeg, hSeg);
     geometry.setAttribute("position", plane.getAttribute("position"));

--- a/src/vertexedit4/app.js
+++ b/src/vertexedit4/app.js
@@ -1,0 +1,144 @@
+/**
+ * Three.js
+ * https://threejs.org/
+ */
+import * as THREE from "three";
+import vertexShader from "./vertex.glsl";
+import fragmentShader from "./fragment.glsl";
+import GUI from "lil-gui";
+import { gsap } from "gsap";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
+import { iNode } from "../iNode";
+
+init();
+async function init() {
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(
+    75,
+    window.innerWidth / window.innerHeight,
+    0.1,
+    1000
+  );
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setClearColor(0xffffff);
+
+  /* エラー時にシェーダの全体のコードを表示(three.js 0.152.0 対応) */
+  renderer.debug.onShaderError = (
+    gl,
+    program,
+    vertexShader,
+    fragmentShader
+  ) => {
+    const vertexShaderSource = gl.getShaderSource(vertexShader);
+    const fragmentShaderSource = gl.getShaderSource(fragmentShader);
+
+    console.groupCollapsed("vertexShader");
+    console.log(vertexShaderSource);
+    console.groupEnd();
+
+    console.groupCollapsed("fragmentShader");
+    console.log(fragmentShaderSource);
+    console.groupEnd();
+  };
+
+  document.body.appendChild(renderer.domElement);
+
+  async function loadTex(url) {
+    const texLoader = new THREE.TextureLoader();
+    const texture = await texLoader.loadAsync(url);
+    texture.wrapS = THREE.ClampToEdgeWrapping;
+    texture.wrapT = THREE.MirroredRepeatWrapping;
+    return texture;
+  }
+
+  function setupGeometry() {
+    const wSeg = 2,
+      hSeg = 5;
+    const geometry = new THREE.BufferGeometry();
+    const plane = new THREE.PlaneGeometry(50, 25, wSeg, hSeg);
+    geometry.setAttribute("position", plane.getAttribute("position"));
+    geometry.setAttribute("plane", plane.getAttribute("position"));
+    geometry.setAttribute("uv", plane.getAttribute("uv"));
+
+    //頂点情報の正規化
+    const maxCount = (wSeg + 1) * (hSeg + 1);
+    console.log(maxCount);
+    const normalizedValues = [];
+    for (let i = 0; i < maxCount; i++) {
+      const norma = i / maxCount;
+      normalizedValues.push(norma);
+    }
+    console.log(normalizedValues);
+    geometry.setAttribute(
+      "normalizedValue",
+      new THREE.Float32BufferAttribute(normalizedValues, 1)
+    );
+    geometry.setAttribute(
+      "normalizedValue1",
+      new THREE.Float32BufferAttribute(normalizedValues, 1)
+    );
+
+    // planegeometryのindexをbuffergeometryにセット
+    const planeIndexs = plane.getIndex().array;
+    geometry.setIndex(new THREE.BufferAttribute(planeIndexs, 1));
+
+    console.log(geometry);
+    return geometry;
+  }
+  const geometry = setupGeometry();
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      uTex: { value: await loadTex("/img/uv.jpg") },
+      uTex1: { value: await loadTex("/img/output5.jpg") },
+      uProgress: { value: 0 },
+      uTick: { value: 0 },
+    },
+    vertexShader,
+    fragmentShader,
+    // wireframe: true,
+    side: THREE.DoubleSide,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  scene.add(mesh);
+  console.log(mesh);
+
+  camera.position.z = 30;
+
+  const axis = new THREE.AxesHelper(100);
+  scene.add(axis);
+
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+
+  const gui = new GUI();
+  const folder1 = gui.addFolder("z-distance");
+  folder1.open();
+
+  folder1
+    .add(material.uniforms.uProgress, "value", 0, 1, 0.1)
+    .name("zaxis")
+    .listen();
+
+  const datData = { next: !!material.uniforms.uProgress.value };
+  folder1
+    .add(datData, "next")
+    .name("moving axis")
+    .onChange(() => {
+      gsap.to(material.uniforms.uProgress, {
+        value: datData.next ? 1 : 0,
+        duration: 3,
+        ease: "ease",
+      });
+    });
+
+  function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+
+    renderer.render(scene, camera);
+  }
+
+  animate();
+}

--- a/src/vertexedit4/app.js
+++ b/src/vertexedit4/app.js
@@ -54,8 +54,8 @@ async function init() {
   }
 
   function setupGeometry() {
-    const wSeg = 2,
-      hSeg = 5;
+    const wSeg = 3,
+      hSeg = 3;
     const geometry = new THREE.BufferGeometry();
     const plane = new THREE.PlaneGeometry(50, 25, wSeg, hSeg);
     geometry.setAttribute("position", plane.getAttribute("position"));
@@ -97,7 +97,7 @@ async function init() {
     },
     vertexShader,
     fragmentShader,
-    // wireframe: true,
+    wireframe: true,
     side: THREE.DoubleSide,
   });
   const mesh = new THREE.Mesh(geometry, material);

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -23,13 +23,11 @@ void main() {
 
     //　ある範囲でdiscardする
     //😃test result　
-    float a = 0.2;//cennte座標と頂点をむずばずに描画
-    float b = 0.5;
 
-    if(v1 > a && v1 < b) {
+    if(0.00< v1 && v1 < 0.29) {
+    // if(0.17 < v1 && v1 < 0.26 && 0.35 < v1 && v1 < 0.42) {
 
         discard;
-        // discard;
     }
 
     gl_FragColor = tex;

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -19,7 +19,7 @@ void main() {
 
     
 
-   if(uc.x > 0.2){
+   if(uv.x > 0.2&& uv.x < 0.8 && uv.y > 0.2 && uv.y < 0.8){
     gl_FragColor = tex;
 
    }

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -13,14 +13,14 @@ void main() {
     vec2 uv = vUv;
     vec3 p = pos * v;
     vec3 p1 = pos * v1;
-
     vec2 uc = clamp(uv, 0.2,0.8);
-
     vec4 tex = texture2D(uTex,uc);
     vec4 tex1 = texture2D(uTex1, uv);
 
     
 
-   
+   if(uc.x > 0.2){
     gl_FragColor = tex;
+
+   }
 }

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -14,12 +14,12 @@ void main() {
     vec3 p = pos * v;
     vec3 p1 = pos * v1;
 
-    // vec4 tex = texture2D(uTex, vUv);
-    vec4 tex = texture2D(uTex, uv);
+    vec2 uc = clamp(uv, 0.2,0.8);
+
+    vec4 tex = texture2D(uTex,uc);
     vec4 tex1 = texture2D(uTex1, uv);
 
-    // gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
-    // gl_FragColor = tex;
+    
 
    
     gl_FragColor = tex;

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -1,0 +1,34 @@
+precision mediump float;
+
+varying float v;
+varying float v1;
+
+uniform sampler2D uTex;
+uniform sampler2D uTex1;
+varying vec2 vUv;
+varying vec3 pos;
+
+void main() {
+
+    vec2 uv = vUv;
+    vec3 p = pos * v;
+    vec3 p1 = pos * v1;
+
+    // vec4 tex = texture2D(uTex, vUv);
+    vec4 tex = texture2D(uTex, uv);
+    vec4 tex1 = texture2D(uTex1, uv);
+
+    // gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = tex;
+
+    //😃test result　値を１.0以下すなわちすべてをdiscardすると描画しなくなる 
+    float a = 1.0;//cennte座標と頂点をむずばずに描画
+    // float a = 0.5;//cennte座標と頂点を半分結んだ状態に描画
+    // float a = 0.0;//center座標と頂点を結んで描画
+
+    if(v1 < a) {
+        discard;
+    }
+
+    gl_FragColor = tex;
+}

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -8,9 +8,6 @@ uniform sampler2D uTex1;
 varying vec2 vUv;
 varying vec3 pos;
 
-varying vec4 vScale1;
-varying vec4 vScale;
-
 void main() {
 
     vec2 uv = vUv;
@@ -24,18 +21,16 @@ void main() {
     // gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
     gl_FragColor = tex;
 
-    //😃test result　値を１.0以下すなわちすべてをdiscardすると描画しなくなる 
-    float a = 1.0;//cennte座標と頂点をむずばずに描画
-    // float a = 0.5;//cennte座標と頂点を半分結んだ状態に描画
-    // float a = 0.0;//center座標と頂点を結んで描画
+    //　ある範囲でdiscardする
+    //😃test result　
+    float a = 0.2;//cennte座標と頂点をむずばずに描画
+    float b = 0.5;
 
-    // if(v1 < a) {
-    //     discard;
-    // }
+    if(v1 > a && v1 < b) {
 
-    // if(vScale1 == vScale1) {
-    //     discard;
-    // }
+        discard;
+        // discard;
+    }
 
     gl_FragColor = tex;
 }

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -8,6 +8,9 @@ uniform sampler2D uTex1;
 varying vec2 vUv;
 varying vec3 pos;
 
+varying vec4 vScale1;
+varying vec4 vScale;
+
 void main() {
 
     vec2 uv = vUv;
@@ -26,9 +29,13 @@ void main() {
     // float a = 0.5;//cennte座標と頂点を半分結んだ状態に描画
     // float a = 0.0;//center座標と頂点を結んで描画
 
-    if(v1 < a) {
-        discard;
-    }
+    // if(v1 < a) {
+    //     discard;
+    // }
+
+    // if(vScale1 == vScale1) {
+    //     discard;
+    // }
 
     gl_FragColor = tex;
 }

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -23,12 +23,8 @@ void main() {
 
     //　ある範囲でdiscardする
     //😃test result　
-
-    if(0.00< v1 && v1 < 0.29) {
-    // if(0.17 < v1 && v1 < 0.26 && 0.35 < v1 && v1 < 0.42) {
-
+    if(v < 1.0) {
         discard;
     }
-
     gl_FragColor = tex;
 }

--- a/src/vertexedit4/fragment.glsl
+++ b/src/vertexedit4/fragment.glsl
@@ -19,12 +19,8 @@ void main() {
     vec4 tex1 = texture2D(uTex1, uv);
 
     // gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
-    gl_FragColor = tex;
+    // gl_FragColor = tex;
 
-    //　ある範囲でdiscardする
-    //😃test result　
-    if(v < 1.0) {
-        discard;
-    }
+   
     gl_FragColor = tex;
 }

--- a/src/vertexedit4/vertex.glsl
+++ b/src/vertexedit4/vertex.glsl
@@ -8,27 +8,15 @@ varying float v;
 varying float v1;
 varying vec3 pos;
 
-varying vec4 vScale1;
-varying vec4 vScale;
+
 
 void main() {
     vUv = uv;
-    v = normalizedValue * 0.5;
+    v = normalizedValue;
     v1 = normalizedValue1;
     pos = position;
 
-    if(v1 < 1.0) {
-        v1 = 1.0; //0.49以下を全て1にする。なので1以下をfragmentのdiscardで１以下で消す
-    } else {
-        v1 = 0.0;
-    }
-
-    vec4 scale = vec4(pos, 1.0);
-    vec4 scale1 = vec4(pos, 2.0);
-    vec4 scale2 = vec4(pos, 1.2);
-
-    vScale1 = scale1;
-    vScale = scale;
-
-    gl_Position = projectionMatrix * modelViewMatrix * (scale1);
+    
+    
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
 }

--- a/src/vertexedit4/vertex.glsl
+++ b/src/vertexedit4/vertex.glsl
@@ -2,8 +2,8 @@ precision mediump float;
 
 varying vec2 vUv;
 
-attribute float normalizedValue;
-attribute float normalizedValue1;
+attribute float normalizedValue;//正規化された値
+
 varying float v;
 varying float v1;
 varying vec3 pos;
@@ -13,9 +13,13 @@ varying vec3 pos;
 void main() {
     vUv = uv;
     v = normalizedValue;
-    v1 = normalizedValue1;
     pos = position;
 
+    if (0.31 < v && v < 0.38) {
+        v = 0.0;
+    } else {
+        v = 1.0;
+    }
     
     
     gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.2);

--- a/src/vertexedit4/vertex.glsl
+++ b/src/vertexedit4/vertex.glsl
@@ -10,15 +10,10 @@ varying vec3 pos;
 
 void main() {
     vUv = uv;
-    v = normalizedValue;
+    v = normalizedValue * 0.5;
     v1 = normalizedValue1;
     pos = position;
 
-    if(v < 0.43) {
-        v = 0.0;
-    } else {
-        v = 1.0;
-    }
 
     if(v1 < 1.0) {
         v1 = 1.0; //0.49以下を全て1にする。なので1以下をfragmentのdiscardで１以下で消す
@@ -26,5 +21,5 @@ void main() {
         v1 = 0.0;
     }
 
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position * v1, 1.2);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position * v, 1.2);
 }

--- a/src/vertexedit4/vertex.glsl
+++ b/src/vertexedit4/vertex.glsl
@@ -18,5 +18,5 @@ void main() {
 
     
     
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.2);
 }

--- a/src/vertexedit4/vertex.glsl
+++ b/src/vertexedit4/vertex.glsl
@@ -8,6 +8,9 @@ varying float v;
 varying float v1;
 varying vec3 pos;
 
+varying vec4 vScale1;
+varying vec4 vScale;
+
 void main() {
     vUv = uv;
     v = normalizedValue * 0.5;
@@ -22,6 +25,10 @@ void main() {
 
     vec4 scale = vec4(pos, 1.0);
     vec4 scale1 = vec4(pos, 2.0);
+    vec4 scale2 = vec4(pos, 1.2);
+
+    vScale1 = scale1;
+    vScale = scale;
 
     gl_Position = projectionMatrix * modelViewMatrix * (scale1);
 }

--- a/src/vertexedit4/vertex.glsl
+++ b/src/vertexedit4/vertex.glsl
@@ -14,12 +14,14 @@ void main() {
     v1 = normalizedValue1;
     pos = position;
 
-
     if(v1 < 1.0) {
         v1 = 1.0; //0.49以下を全て1にする。なので1以下をfragmentのdiscardで１以下で消す
     } else {
         v1 = 0.0;
     }
 
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position * v, 1.2);
+    vec4 scale = vec4(pos, 1.0);
+    vec4 scale1 = vec4(pos, 2.0);
+
+    gl_Position = projectionMatrix * modelViewMatrix * (scale1);
 }

--- a/src/vertexedit4/vertex.glsl
+++ b/src/vertexedit4/vertex.glsl
@@ -1,0 +1,30 @@
+precision mediump float;
+
+varying vec2 vUv;
+
+attribute float normalizedValue;
+attribute float normalizedValue1;
+varying float v;
+varying float v1;
+varying vec3 pos;
+
+void main() {
+    vUv = uv;
+    v = normalizedValue;
+    v1 = normalizedValue1;
+    pos = position;
+
+    if(v < 0.43) {
+        v = 0.0;
+    } else {
+        v = 1.0;
+    }
+
+    if(v1 < 1.0) {
+        v1 = 1.0; //0.49以下を全て1にする。なので1以下をfragmentのdiscardで１以下で消す
+    } else {
+        v1 = 0.0;
+    }
+
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position * v1, 1.2);
+}

--- a/src/vertexedit4/vertex.glsl
+++ b/src/vertexedit4/vertex.glsl
@@ -8,19 +8,10 @@ varying float v;
 varying float v1;
 varying vec3 pos;
 
-
-
 void main() {
     vUv = uv;
     v = normalizedValue;
     pos = position;
 
-    if (0.31 < v && v < 0.38) {
-        v = 0.0;
-    } else {
-        v = 1.0;
-    }
-    
-    
     gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.2);
 }


### PR DESCRIPTION
positionを消すとvertexがなくなるので面がつくれないところがでてしまう。アプローチ方法が間違っているようだった。

なので、uv座標で0.2から0.8をx、yともに描画できないか確認。
0.0から0.2までは描画しなくなるスペースはなくなり、結果全体サイズは0.8倍になった。

clampと条件式がセットで必要した。
`vec2 uc = clamp(uv, 0.2,0.8);`
uv 0.0から0.1を表示させない、0.9−1.0を表示させないための記述である。0.2−0.8で線形補完が始まるのかな。値が動くようにしたので、結果が向上したのだと思います。

条件分岐
`if(uv.x > 0.2&& uv.x < 0.8 && uv.y > 0.2 && uv.y < 0.8){`
uv.xとuv.yの閾値に合致したら描画するようにした