### PR TITLE
Refactor3 tex1

### DIFF
--- a/src/temple_refactor3_tex/scripts/fragment.glsl
+++ b/src/temple_refactor3_tex/scripts/fragment.glsl
@@ -1,12 +1,13 @@
 precision mediump float;
 
 varying vec2 vUv;
-uniform sampler2D uTex1;
+uniform sampler2D tex1;
+uniform sampler2D tex2;
 
 void main() {
 
 vec2 uv = vUv;
-vec4 texColor = texture2D(uTex1, uv);
+vec4 texColor = texture2D(tex1, uv);
 gl_FragColor = texColor;
 
 }

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -59,9 +59,12 @@ async function _initObjects() {
     for (let key in data) {
       //datasetのプロパティをループさせる
       if (key.startsWith("tex")) {
-        key =key.replace("-","");
+        key = key.replace("-", "");
         texes.push(key);
+        console.log(key);
       }
+      const url = data[key];
+      console.log(url);
     }
     console.log(data);
     console.log(texes);

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -56,15 +56,18 @@ async function _initObjects() {
     const texes = [];
 
     const data = el.dataset;
-    for(let key in data) {//datasetのプロパティをループさせる
-      texes.push(key);
+    for (let key in data) {
+      //datasetのプロパティをループさせる
+      if (key.startsWith("tex")) {
+        key =key.replace("-","");
+        texes.push(key);
+      }
     }
     console.log(data);
     console.log(texes);
 
     const url1 = el.dataset["tex-1"];
     const url2 = el.dataset["tex-2"];
-    console.log(url2);
 
     const tex1 = await texLoader.loadAsync(url1);
     const tex2 = await texLoader.loadAsync(url2);

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -61,15 +61,13 @@ async function _initObjects() {
       if (!key.startsWith("tex")) continue;
       const url = data[key];
       const tex = await texLoader.loadAsync(url);
+
       key = key.replace("-", "");
       texes.set(key, tex);
+      // console.log(key);
+      // console.log(tex);
     }
     console.log(texes);
-
-    const url1 = el.dataset["tex-1"];
-    // const url2 = el.dataset["tex-2"];
-
-    // const tex1 = await texLoader.loadAsync(url1);
 
     const geometry = new PlaneGeometry(rect.width, rect.height, 1, 1);
     const material = new ShaderMaterial({
@@ -82,9 +80,9 @@ async function _initObjects() {
       vertexShader,
       fragmentShader,
     });
-
-    material.uniforms.uTex1 = { value: texes.get("tex1") };
-
+    texes.forEach((key, tex) => {
+      material.uniforms[key] = { value: tex };
+    });
     const mesh = new Mesh(geometry, material);
     mesh.position.z = 0; //追加⭐️⭐️0830
 

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -51,12 +51,15 @@ async function _initObjects() {
   console.log(0);
   const prms = [...els].map(async (el) => {
     const rect = el.getBoundingClientRect();
+    const url = el.dataset["tex-1"];
+    // const url = "/img/output3.jpg";
+    console.log(url);
     const geometry = new PlaneGeometry(rect.width, rect.height, 1, 1);
     const material = new ShaderMaterial({
       uniforms: {
         uMouse: { value: new Vector2(0.5, 0.5) },
         uHover: { value: 0 },
-        uTex1: { value: await loadTex("/img/output1.jpg") },
+        uTex1: { value: await loadTex(url) },
         // uTex2: { value: await loadTex("/img/output2.jpg") },
         uTick: { value: 0 },
         uProgress: { value: 0 },

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -58,7 +58,7 @@ async function _initObjects() {
     const data = el.dataset;
     for (let key in data) {
       //datasetのプロパティをループさせる
-      if (!key.startsWith("tex")) continue; 
+      if (!key.startsWith("tex")) continue;
       const url = data[key];
       const tex = await texLoader.loadAsync(url);
       key = key.replace("-", "");
@@ -74,7 +74,6 @@ async function _initObjects() {
     const geometry = new PlaneGeometry(rect.width, rect.height, 1, 1);
     const material = new ShaderMaterial({
       uniforms: {
-        uTex1: { value: tex1 },
         uMouse: { value: new Vector2(0.5, 0.5) },
         uHover: { value: 0 },
         uTick: { value: 0 },
@@ -83,6 +82,8 @@ async function _initObjects() {
       vertexShader,
       fragmentShader,
     });
+
+    material.uniforms.uTex1 = { value: texes.get("tex1") };
 
     const mesh = new Mesh(geometry, material);
     mesh.position.z = 0; //追加⭐️⭐️0830

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -53,27 +53,23 @@ async function _initObjects() {
   const prms = [...els].map(async (el) => {
     const rect = el.getBoundingClientRect();
 
-    const texes = [];
+    const texes = new Map();
 
     const data = el.dataset;
     for (let key in data) {
       //datasetのプロパティをループさせる
-      if (key.startsWith("tex")) {
-        key = key.replace("-", "");
-        texes.push(key);
-        console.log(key);
-      }
+      if (!key.startsWith("tex")) continue; 
       const url = data[key];
-      console.log(url);
+      const tex = await texLoader.loadAsync(url);
+      key = key.replace("-", "");
+      texes.set(key, tex);
     }
-    console.log(data);
     console.log(texes);
 
     const url1 = el.dataset["tex-1"];
-    const url2 = el.dataset["tex-2"];
+    // const url2 = el.dataset["tex-2"];
 
-    const tex1 = await texLoader.loadAsync(url1);
-    const tex2 = await texLoader.loadAsync(url2);
+    // const tex1 = await texLoader.loadAsync(url1);
 
     const geometry = new PlaneGeometry(rect.width, rect.height, 1, 1);
     const material = new ShaderMaterial({

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -55,9 +55,16 @@ async function _initObjects() {
 
     const texes = [];
 
+    const data = el.dataset;
+    for(let key in data) {//datasetのプロパティをループさせる
+      texes.push(key);
+    }
+    console.log(data);
+    console.log(texes);
+
     const url1 = el.dataset["tex-1"];
     const url2 = el.dataset["tex-2"];
-    console.log(url1);
+    console.log(url2);
 
     const tex1 = await texLoader.loadAsync(url1);
     const tex2 = await texLoader.loadAsync(url2);

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -80,7 +80,7 @@ async function _initObjects() {
       vertexShader,
       fragmentShader,
     });
-    texes.forEach((key, tex) => {
+    texes.forEach((tex, key) => {
       material.uniforms[key] = { value: tex };
     });
     const mesh = new Mesh(geometry, material);

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -27,6 +27,8 @@ const world = {
   raycaster: new Raycaster(),
 };
 
+const texLoader = new TextureLoader();
+
 const canvas = iNode.qs("#canvas");
 const canvasRect = canvas.getBoundingClientRect();
 
@@ -54,12 +56,17 @@ async function _initObjects() {
     const url = el.dataset["tex-1"];
     // const url = "/img/output3.jpg";
     console.log(url);
+
+    const tex = await texLoader.loadAsync(url);
+    console.log(tex);
+
     const geometry = new PlaneGeometry(rect.width, rect.height, 1, 1);
     const material = new ShaderMaterial({
       uniforms: {
         uMouse: { value: new Vector2(0.5, 0.5) },
         uHover: { value: 0 },
-        uTex1: { value: await loadTex(url) },
+        uTex1: { value: tex },
+        // uTex1: { value: await loadTex(url) },
         // uTex2: { value: await loadTex("/img/output2.jpg") },
         uTick: { value: 0 },
         uProgress: { value: 0 },

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -50,24 +50,24 @@ function init(canvas, viewport) {
 
 async function _initObjects() {
   const els = iNode.qsa("[data-webgl]");
-  console.log(0);
   const prms = [...els].map(async (el) => {
     const rect = el.getBoundingClientRect();
-    const url = el.dataset["tex-2"];
-    // const url = "/img/output3.jpg";
-    console.log(url);
 
-    const tex = await texLoader.loadAsync(url);
-    console.log(tex);
+    const texes = [];
+
+    const url1 = el.dataset["tex-1"];
+    const url2 = el.dataset["tex-2"];
+    console.log(url1);
+
+    const tex1 = await texLoader.loadAsync(url1);
+    const tex2 = await texLoader.loadAsync(url2);
 
     const geometry = new PlaneGeometry(rect.width, rect.height, 1, 1);
     const material = new ShaderMaterial({
       uniforms: {
-        uTex1: { value: tex },
+        uTex1: { value: tex1 },
         uMouse: { value: new Vector2(0.5, 0.5) },
         uHover: { value: 0 },
-        // uTex1: { value: await loadTex(url) },
-        // uTex2: { value: await loadTex("/img/output2.jpg") },
         uTick: { value: 0 },
         uProgress: { value: 0 },
       },
@@ -90,7 +90,6 @@ async function _initObjects() {
     };
     world.scene.add(mesh);
     world.os.push(o);
-    console.log(3);
 
     // const gui = new GUI();
     // const folder1 = gui.addFolder("");
@@ -116,7 +115,6 @@ async function _initObjects() {
     // viewport._initResize();
   });
   await Promise.all(prms);
-  console.log(1);
   fitWorldPositon(viewport);
 
   mousePick.init();
@@ -130,7 +128,6 @@ function setupPerspectiveCamera(viewport) {
 }
 
 function fitWorldPositon(viewport) {
-  console.log(2);
   world.renderer.setSize(viewport.width, viewport.height, false);
 
   world.os.forEach((o) => resize(o, viewport)); //newCanvasRectをviewportに変更

--- a/src/temple_refactor3_tex/scripts/glsl/world.js
+++ b/src/temple_refactor3_tex/scripts/glsl/world.js
@@ -53,7 +53,7 @@ async function _initObjects() {
   console.log(0);
   const prms = [...els].map(async (el) => {
     const rect = el.getBoundingClientRect();
-    const url = el.dataset["tex-1"];
+    const url = el.dataset["tex-2"];
     // const url = "/img/output3.jpg";
     console.log(url);
 
@@ -63,9 +63,9 @@ async function _initObjects() {
     const geometry = new PlaneGeometry(rect.width, rect.height, 1, 1);
     const material = new ShaderMaterial({
       uniforms: {
+        uTex1: { value: tex },
         uMouse: { value: new Vector2(0.5, 0.5) },
         uHover: { value: 0 },
-        uTex1: { value: tex },
         // uTex1: { value: await loadTex(url) },
         // uTex2: { value: await loadTex("/img/output2.jpg") },
         uTick: { value: 0 },

--- a/src/tex.html
+++ b/src/tex.html
@@ -11,9 +11,9 @@
   </head>
   <body>
     <div id="page-container">
-      <div class="test" data-webgl data-tex-1="/img/output5.jpg"></div>
-      <section data-webgl data-tex-1="/img/output3.jpg"></section>
-      <img data-webgl data-tex-1="/img/output3.jpg" src="../img/output3.jpg"  data-tex-2="/img/output4.jpg" src="../img/output4.jpg" />
+      <!-- <div class="test" data-webgl data-tex-1="/img/output5.jpg"></div>
+      <section data-webgl data-tex-1="/img/output3.jpg"></section> -->
+      <img data-webgl data-tex-1="/img/output3.jpg"  data-tex-2="/img/output4.jpg" src="" />
 
       <style>
         canvas {

--- a/src/tex.html
+++ b/src/tex.html
@@ -11,8 +11,8 @@
   </head>
   <body>
     <div id="page-container">
-      <!-- <div class="test" data-webgl></div>
-      <section data-webgl></section> -->
+      <div class="test" data-webgl data-tex-1="/img/output5.jpg"></div>
+      <section data-webgl data-tex-1="/img/output3.jpg"></section>
       <img data-webgl data-tex-1="/img/output3.jpg" src="../img/output6.jpg" />
 
       <style>

--- a/src/tex.html
+++ b/src/tex.html
@@ -11,9 +11,9 @@
   </head>
   <body>
     <div id="page-container">
-      <div class="test" data-webgl></div>
-      <section data-webgl></section>
-      <img data-webgl src="../img/output6.jpg" />
+      <!-- <div class="test" data-webgl></div>
+      <section data-webgl></section> -->
+      <img data-webgl data-tex-1="/img/output3.jpg" src="../img/output6.jpg" />
 
       <style>
         canvas {

--- a/src/tex.html
+++ b/src/tex.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      Memorandum of understanding and practice journey when implementing
+    </title>
+    <!-- <link rel="stylesheet" href="style copy.css" /> -->
+    <script type="module" src="./temple_refactor3_tex/scripts/index.js"></script>
+  </head>
+  <body>
+    <div id="page-container">
+      <div class="test" data-webgl></div>
+      <section data-webgl></section>
+      <img data-webgl src="../img/output6.jpg" />
+
+      <style>
+        canvas {
+          margin: 0;
+          position: fixed;
+        }
+        .test {
+          margin-top: 100px;
+          margin-left: 200px;
+          width: 256px;
+          height: 144px;
+          background: rgb(232, 231, 231);
+          opacity: 0.3;
+          /* overflow: hidden; */
+          z-index: 1;
+        }
+        section {
+          margin-top: 350px;
+          margin-left: 200px;
+          width: 256px;
+          height: 144px;
+          background: rgb(206, 206, 206);
+          opacity: 0.3;
+        }
+        img {
+
+          margin-top: 350px;
+          margin-left: 200px;
+          width: 500px;
+          height: 300px;
+          opacity: 0.3;
+        }
+      </style>
+    </div>
+    <canvas id="canvas"></canvas>
+  </body>
+</html>

--- a/src/tex.html
+++ b/src/tex.html
@@ -13,7 +13,7 @@
     <div id="page-container">
       <div class="test" data-webgl data-tex-1="/img/output5.jpg"></div>
       <section data-webgl data-tex-1="/img/output3.jpg"></section>
-      <img data-webgl data-tex-1="/img/output3.jpg" src="../img/output6.jpg" />
+      <img data-webgl data-tex-1="/img/output3.jpg" src="../img/output3.jpg"  data-tex-2="/img/output4.jpg" src="../img/output4.jpg" />
 
       <style>
         canvas {


### PR DESCRIPTION
### Shaderaterialのuniforomからのtexture登録を分離

> data属性をhtmlから取得する
`const data = el.dataset;`
>console.log(data);=> DOMStringMap {webgl: '', tex-1: '/img/output3.jpg', tex-2: '/img/output4.jpg'}

> 二つ組み合わせでデータ維持したいときはnew Mapがよい
`const texes = new Map();`
登録も簡単です。
`texes.set(key, tex);`

> forEachメソッドのコールバック関数は引数の順序は重要
```
texes.forEach((tex, key) => {
      material.uniforms[key] = { value: tex };
    });
```
コールバック関数の第一引数は通常、要素の値を表し、第二引数は通常、その要素のインデックス（またはキー）を表します。
＊逆にして表示しなくてしばらくわからなかったです。
