### PR TITLE
feat:01 単純に拡大縮小はuResolutionの係数を掛け合わせたらできた。

### DIFF
--- a/src/temple_refactor3_tex3 copy/scripts/fragment.glsl
+++ b/src/temple_refactor3_tex3 copy/scripts/fragment.glsl
@@ -5,10 +5,9 @@ uniform sampler2D tex1;
 uniform sampler2D tex2;
 
 uniform vec4 uResolution;
-vec2 coverUv(vec2 uv , vec4 uResolution) {
-return (uv - .5) * uResolution.zw + .5;
+vec2 coverUv(vec2 uv, vec4 uResolution) {
+  return (uv - .5) * uResolution.zw*0.9 + .5;
 }
-
 
 uniform vec4 uVClamp;
 // vec2 clampUv(vec2 uv, vec4 uVClamp) {
@@ -19,20 +18,19 @@ uniform vec4 uVClamp;
 void main() {
 
   // vec2 uv = vUv;
-vec2 uvb = coverUv(vUv, uResolution);
+  vec2 uvb = coverUv(vUv, uResolution);
 
 // vec2 uva = clampUv(vUv, uVClamp);
 // vec4 texColor3 = texture2D(tex1, uva);
-vec2 uvz = clamp(vUv, uVClamp.xy, uVClamp.zw);
+  vec2 uvz = clamp(vUv, uVClamp.xy, uVClamp.zw);
 
-vec4 texColor1 = texture2D(tex1, uvb);
-vec4 texColor11 = texture2D(tex1, vUv);
-vec4 texColor2 = texture2D(tex2, uvb);
+  vec4 texColor1 = texture2D(tex1, uvb);
+  vec4 texColor11 = texture2D(tex1, vUv);
+  vec4 texColor2 = texture2D(tex2, uvb);
 
-gl_FragColor = mix(texColor1, texColor2, smoothstep(0.3, 0.5, vUv.x));
-gl_FragColor = texColor11;
-gl_FragColor = texColor1;
+  gl_FragColor = mix(texColor1, texColor2, smoothstep(0.3, 0.5, vUv.x));
+  gl_FragColor = texColor11;
+  gl_FragColor = texColor1;
 // gl_FragColor = texture2D(tex1, uvz);
-
 
 }

--- a/src/tex.html
+++ b/src/tex.html
@@ -9,9 +9,10 @@
     <!-- <link rel="stylesheet" href="style copy.css" /> -->
     <script
       type="module"
-      src="./temple_refactor3_tex4/scripts/index.js"
+      src="./temple_refactor3_tex3 copy/scripts/index.js"
     ></script>
-    <link rel="stylesheet" href="./temple_refactor3_tex4/styles/loader.scss" />
+    <!-- <link rel="stylesheet" href="./temple_refactor3_tex4/styles/loader.scss" /> -->
+    <link rel="stylesheet" href="./style.scss" />
   </head>
   <body>
     <div id="loader" class="loader">


### PR DESCRIPTION
### 単純な拡大縮小の制御
_保存先./temple_refactor3_tex3 copy/scripts/index.js_

> vec4を新たに作成
`uniform vec4 uResolution;`
uResolutionを計算しているのですが、これは中央から0.5ピッチuvを揃えている

> uvを上記で求めたアスペクト比で計算している。−0.5から0.5で計算したほうがやりやすい
` return (uv - .5) * uResolution.zw*0.9 + .5;`

> 関数作成
`coverUv(vUv, uResolution);`

最後に独自のuvから出力をします。
`vec4 texColor1 = texture2D(tex1, uvb);`