### PR TITLE
Bottom resize

### DIFF
--- a/src/001_dev_style/scripts/glsl/world.js
+++ b/src/001_dev_style/scripts/glsl/world.js
@@ -155,6 +155,7 @@ function osResize() {
   world.camera.far = viewport.far;
   world.camera.aspect = viewport.aspect;
   world.camera.updateProjectionMatrix();
+  console.log("world resize");
 }
 
 export default world;

--- a/src/001_dev_style/scripts/myclasses/viewport.js
+++ b/src/001_dev_style/scripts/myclasses/viewport.js
@@ -21,4 +21,4 @@ class ViewPort {
   }
 }
 
-export default ViewPort;
+// export default ViewPort;

--- a/src/001_dev_style/scripts/page/bottom_1.js
+++ b/src/001_dev_style/scripts/page/bottom_1.js
@@ -27,30 +27,20 @@ export default async function init({
 
   let resizeTimer;
 
-  window.addEventListener("resize", {
-    handleEvent(event) {
-      clearTimeout(resizeTimer);
+  window.addEventListener("resize", () => {
+    clearTimeout(resizeTimer);
 
-      updateHeaderStyle();
-      // resizeTimer = setTimeout(() => {
-      //   let height = 0;
-      //   domManuipulator.init();
-      //   const headerHeight = headerHandler.getHeaderHeight();
-      //   domManuipulator.updateStyle(headerHeight);
-      //   height = headerHandler.getHeaderHeight();
-      //   headerHandler.setElHeight(height);
-      // }, 200);
-    },
+    updateHeaderStyle();
   });
 
   function updateHeaderStyle() {
     resizeTimer = setTimeout(() => {
-      let height = 0;
+      let nextHeight = 0;
       domManuipulator.init();
       const headerHeight = headerHandler.getHeaderHeight();
       domManuipulator.updateStyle(headerHeight);
-      height = headerHandler.getHeaderHeight();
-      headerHandler.setElHeight(height);
+      nextHeight = headerHandler.getHeaderHeight();
+      headerHandler.setElHeight(nextHeight);
     }, 200);
   }
 

--- a/src/001_dev_style/scripts/page/bottom_1.js
+++ b/src/001_dev_style/scripts/page/bottom_1.js
@@ -31,16 +31,28 @@ export default async function init({
     handleEvent(event) {
       clearTimeout(resizeTimer);
 
-      resizeTimer = setTimeout(() => {
-        let height = 0;
-        domManuipulator.init();
-        const headerHeight = headerHandler.getHeaderHeight();
-        domManuipulator.updateStyle(headerHeight);
-        height = headerHandler.getHeaderHeight();
-        headerHandler.setElHeight(height);
-      }, 200);
+      updateHeaderStyle();
+      // resizeTimer = setTimeout(() => {
+      //   let height = 0;
+      //   domManuipulator.init();
+      //   const headerHeight = headerHandler.getHeaderHeight();
+      //   domManuipulator.updateStyle(headerHeight);
+      //   height = headerHandler.getHeaderHeight();
+      //   headerHandler.setElHeight(height);
+      // }, 200);
     },
   });
+
+  function updateHeaderStyle() {
+    resizeTimer = setTimeout(() => {
+      let height = 0;
+      domManuipulator.init();
+      const headerHeight = headerHandler.getHeaderHeight();
+      domManuipulator.updateStyle(headerHeight);
+      height = headerHandler.getHeaderHeight();
+      headerHandler.setElHeight(height);
+    }, 200);
+  }
 
   // test code for bottom_1.scss
 
@@ -72,7 +84,6 @@ export default async function init({
     };
 
     const scrollBar = Scrollbar.init(page, options);
-    console.log("scrollBar", scrollBar.addListener);
     addScrollBarListener(scrollBar, imgContrast, initialY);
   })(function (scrollBar, imgContrast, initialY) {
     scrollBar.addListener(({ offset }) => {


### PR DESCRIPTION
addEventListenerの第二引数を省略して、updateHeaderStyle()関数をつくって、分離させた。リサイズをworld.jsに移動することを検討していたが、page毎のjsはclassをつくって継承させるほうが再利用がよさそうなので、classを作っていくことにする